### PR TITLE
Underscores in pragmas are not escaped by lhs2tex

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ default : CS410.pdf
 
 CS410.tex : CS410.lagda Introduction.lagda BasicPrelude.lagda EmacsCheatSheet.lagda Logic.lagda Razor.lagda
 	lhs2TeX --agda CS410.lagda > CS410.tex
+	sed -i 's/_==_/\\_==\\_/g' CS410.tex
 
 CS410.aux : CS410.tex
 	latex CS410


### PR DESCRIPTION
Bug reported upstream & it won't be fixed [1]. This is an ad-hoc
solution to get the notes to compile.

[1] https://github.com/kosmikus/lhs2tex/issues/32
